### PR TITLE
Added yearly spending column chart 

### DIFF
--- a/client/src/components/BudgetForm.jsx
+++ b/client/src/components/BudgetForm.jsx
@@ -147,15 +147,18 @@ const BudgetForm = ({
           <input
             type="Date"
             id="add-datepaid"
+            max={`${year}-${getMonthNum(month)}-${getDayNum(month)}`}
             value={expense.datepaid ? removeTimeZone(expense.datepaid) : ""}
             onChange={(event) => handleChange("datepaid", event.target.value)}
           />
         </Form.Group>
-        <Form.Group>
+        <Form.Group required>
           <TagsDropDown expense={expense} setExpense={setExpense} />
         </Form.Group>
         <Form.Group>
           {editExpense ? (
+            // TODO: disable button toggle
+            // Checkout isRequired from material UI
             <Button type="submit" variant="success">
               Edit Expense
             </Button>

--- a/client/src/components/GenTable.jsx
+++ b/client/src/components/GenTable.jsx
@@ -2,7 +2,6 @@ import { Table } from "react-bootstrap";
 import { parseDate } from "./handleDates";
 
 const GenerateTables = ({ expenses }) => {
-  console.log(expenses);
   return expenses && expenses.length ? (
     <>
       <h2>Spendings</h2>

--- a/client/src/components/GenTable.jsx
+++ b/client/src/components/GenTable.jsx
@@ -2,7 +2,8 @@ import { Table } from "react-bootstrap";
 import { parseDate } from "./handleDates";
 
 const GenerateTables = ({ expenses }) => {
-  return (
+  console.log(expenses);
+  return expenses && expenses.length ? (
     <>
       <h2>Spendings</h2>
       <Table bordered hover>
@@ -15,21 +16,21 @@ const GenerateTables = ({ expenses }) => {
           </tr>
         </thead>
         <tbody>
-          {expenses
-            ? expenses.map((expense, index) => {
-                return (
-                  <tr key={index}>
-                    <td>{expense.expense_name}</td>
-                    <td>{expense.amount}</td>
-                    <td>{parseDate(expense.duedate)}</td>
-                    <td>{parseDate(expense.datepaid)}</td>
-                  </tr>
-                );
-              })
-            : null}
+          {expenses.map((expense, index) => {
+            return (
+              <tr key={index}>
+                <td>{expense.expense_name}</td>
+                <td>{expense.amount}</td>
+                <td>{parseDate(expense.duedate)}</td>
+                <td>{parseDate(expense.datepaid)}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </Table>
     </>
+  ) : (
+    <h2> No Spendings to Show </h2>
   );
 };
 export default GenerateTables;

--- a/server/server.js
+++ b/server/server.js
@@ -279,6 +279,45 @@ app.put("/income/:incomeId", cors(), async (req, res) => {
   }
 });
 
+
+/***************************************************************************************************
+ **************************************** YEAR API CALLS  ******************************************
+ ***************************************************************************************************/
+// grab income amount by year and user id 
+app.get("/yearly/income/:userId&:yearNum", cors(), async (req, res) => {
+  const user_id = req.params.userId;
+  const yearNum = req.params.yearNum;
+  try {
+    const { rows: incomes } = await db.query(
+      "SELECT amount, month FROM incomes WHERE user_id = $1 AND year iLike $2",
+      [user_id, yearNum]
+    );
+    console.log(incomes);
+    res.send(incomes);
+  } catch (e) {
+    return res.status(400).json({ e });
+  }
+});
+
+// grab expenses amount + tags by year and user id 
+app.get("/yearly/expenses/:userId&:yearNum", cors(), async (req, res) => {
+  const user_id = req.params.userId;
+  const yearNum = req.params.yearNum;
+  try {
+    const { rows: expenses } = await db.query(
+      "SELECT amount, month FROM expenses WHERE user_id = $1 AND year iLike $2",
+      [user_id, yearNum]
+    );
+    console.log(expenses);
+    res.send(expenses);
+  } catch (e) {
+    return res.status(400).json({ e });
+  }
+});
+
+
+
+
 // console.log that your server is up and running
 app.listen(PORT, () => {
   console.log(`Hola, Server listening on ${PORT}`);


### PR DESCRIPTION
- Added a yearly spending chart that can be adjusted by year selection. Table focuses on spending and income only.
- Expense table is now only rendered if there is data present inside the expense object. If no data is present, renders a header that says "Nothing to Show." 